### PR TITLE
Incorrect number of samples passed to group mix callback

### DIFF
--- a/src/SDL_mixer.c
+++ b/src/SDL_mixer.c
@@ -460,7 +460,7 @@ static void SDLCALL MixerCallback(void *userdata, SDL_AudioStream *stream, int a
         }
 
         if (group->postmix_callback) {
-            group->postmix_callback(group->postmix_callback_userdata, group, &mixer->spec, group_mixbuf, additional_amount);
+            group->postmix_callback(group->postmix_callback_userdata, group, &mixer->spec, group_mixbuf, additional_amount / sizeof (float));
         }
 
         if (!skip_group_mixing) {


### PR DESCRIPTION
`MIX_GroupMixCallback` expects `samples` (same as `MIX_TrackMixCallback`) but bytes (`additional_amount`) are passed, causing the callback to write outside of the `group_mixbuf`.

Related: Is there a reason `MIX_PostMixCallback` expects bytes (based on the name `buflen`)?