### PR TITLE
Specify the exact type

### DIFF
--- a/src/decoder_opus.c
+++ b/src/decoder_opus.c
@@ -43,7 +43,7 @@
     MIX_LOADER_FUNCTION(true,const OpusHead *,op_head,(const OggOpusFile *,int)) \
     MIX_LOADER_FUNCTION(true,int,op_seekable,(const OggOpusFile *)) \
     MIX_LOADER_FUNCTION(true,int,op_read_float,(OggOpusFile *, float *,int,int *)) \
-    MIX_LOADER_FUNCTION(true,int,op_raw_seek,(OggOpusFile *,ogg_int64_t)) \
+    MIX_LOADER_FUNCTION(true,int,op_raw_seek,(OggOpusFile *,opus_int64)) \
     MIX_LOADER_FUNCTION(true,int,op_pcm_seek,(OggOpusFile *,ogg_int64_t)) \
     MIX_LOADER_FUNCTION(true,ogg_int64_t,op_pcm_tell,(const OggOpusFile *)) \
     MIX_LOADER_FUNCTION(true,ogg_int64_t,op_pcm_total,(const OggOpusFile *, int)) \


### PR DESCRIPTION
There is a type mismatch for opus op_raw_seek argument (kinda):

https://github.com/xiph/opusfile/blob/68030a507962284d583416ee37f9a8e580bf369f/include/opusfile.h#L1674

Both `ogg_int64_t` and `opus_int64` should be the same so this shouldn't be a problem. So the fact that compilation fails on this on my configuration points to a problem on my side, **_but_** using `opus_int64` here seem more correct in any case (matching opusfile.h). Thoughts?