### PR TITLE
Complete/Correct the MIX_LoadRawAudioNoCopy function declaration

### DIFF
--- a/include/SDL3_mixer/SDL_mixer.h
+++ b/include/SDL3_mixer/SDL_mixer.h
@@ -146,7 +146,7 @@ extern SDL_DECLSPEC MIX_Audio * SDLCALL MIX_LoadRawAudio_IO(MIX_Mixer *mixer, SD
 extern SDL_DECLSPEC MIX_Audio * SDLCALL MIX_LoadRawAudio(MIX_Mixer *mixer, const void *data, size_t datalen, const SDL_AudioSpec *spec);
 
 // Load raw PCM data to a MIX_Audio. SDL_mixer will NOT make a copy, it must live until the MIX_Audio is destroyed. if free_when_done, SDL_mixer will SDL_free(data) when the MIX_Audio is destroyed.
-MIX_Audio *MIX_LoadRawAudioNoCopy(MIX_Mixer *mixer, const void *data, size_t datalen, const SDL_AudioSpec *spec, bool free_when_done);
+extern SDL_DECLSPEC MIX_Audio * SDLCALL MIX_LoadRawAudioNoCopy(MIX_Mixer *mixer, const void *data, size_t datalen, const SDL_AudioSpec *spec, bool free_when_done);
 
 // just in case you need some audio to play, this will generate a sine wave forever when assigned to a playing Track.
 extern SDL_DECLSPEC MIX_Audio * SDLCALL MIX_CreateSineWaveAudio(MIX_Mixer *mixer, int hz, float amplitude);


### PR DESCRIPTION
Without the SDL_DECLSPEC SDLCALL, I get "function not found" linking errors when building on windows.